### PR TITLE
Allow to not use BOARD pin numbers

### DIFF
--- a/RFM69/radio.py
+++ b/RFM69/radio.py
@@ -23,8 +23,9 @@ class Radio(object):
             auto_acknowledge (bool): Automatically send acknowledgements
             isHighPower (bool): Is this a high power radio model
             power (int): Power level - a percentage in range 10 to 100.
-            interruptPin (int): Pin number of interrupt pin. This is a pin index not a GPIO number.
-            resetPin (int): Pin number of reset pin. This is a pin index not a GPIO number.
+            board_pin_numbers (bool): Force BOARD (not BCM) pin numbers. Defaults to True.
+            interruptPin (int): Pin number of interrupt pin.
+            resetPin (int): Pin number of reset pin.
             spiBus (int): SPI bus number.
             spiDevice (int): SPI device number.
             promiscuousMode (bool): Listen to all messages not just those addressed to this node ID.
@@ -38,10 +39,12 @@ class Radio(object):
 
         self.address = nodeID
 
+        self.board_pin_numbers = kwargs.get('board_pin_numbers', True)
+
         self.auto_acknowledge = kwargs.get('autoAcknowledge', True)
         self.isRFM69HW = kwargs.get('isHighPower', True)
-        self.intPin = kwargs.get('interruptPin', 18)
-        self.rstPin = kwargs.get('resetPin', 29)
+        self.intPin = kwargs.get('interruptPin', 18 if self.board_pin_numbers else 24)
+        self.rstPin = kwargs.get('resetPin', 29 if self.board_pin_numbers else 5)
         self.spiBus = kwargs.get('spiBus', 0)
         self.spiDevice = kwargs.get('spiDevice', 0)
         self.promiscuousMode = kwargs.get('promiscuousMode', 0)
@@ -74,7 +77,9 @@ class Radio(object):
         self._init_interrupt()
 
     def _init_gpio(self):
-        GPIO.setmode(GPIO.BOARD)
+        if self.board_pin_numbers:
+            GPIO.setmode(GPIO.BOARD)
+
         GPIO.setup(self.intPin, GPIO.IN)
         GPIO.setup(self.rstPin, GPIO.OUT)
 

--- a/build/lib/RFM69/radio.py
+++ b/build/lib/RFM69/radio.py
@@ -23,8 +23,9 @@ class Radio(object):
             auto_acknowledge (bool): Automatically send acknowledgements
             isHighPower (bool): Is this a high power radio model
             power (int): Power level - a percentage in range 10 to 100.
-            interruptPin (int): Pin number of interrupt pin. This is a pin index not a GPIO number.
-            resetPin (int): Pin number of reset pin. This is a pin index not a GPIO number.
+            board_pin_numbers (bool): Force BOARD (not BCM) pin numbers. Defaults to True.
+            interruptPin (int): Pin number of interrupt pin.
+            resetPin (int): Pin number of reset pin.
             spiBus (int): SPI bus number.
             spiDevice (int): SPI device number.
             promiscuousMode (bool): Listen to all messages not just those addressed to this node ID.
@@ -38,10 +39,12 @@ class Radio(object):
 
         self.address = nodeID
 
+        self.board_pin_numbers = kwargs.get('board_pin_numbers', True)
+
         self.auto_acknowledge = kwargs.get('autoAcknowledge', True)
         self.isRFM69HW = kwargs.get('isHighPower', True)
-        self.intPin = kwargs.get('interruptPin', 18)
-        self.rstPin = kwargs.get('resetPin', 29)
+        self.intPin = kwargs.get('interruptPin', 18 if self.board_pin_numbers else 24)
+        self.rstPin = kwargs.get('resetPin', 29 if self.board_pin_numbers else 5)
         self.spiBus = kwargs.get('spiBus', 0)
         self.spiDevice = kwargs.get('spiDevice', 0)
         self.promiscuousMode = kwargs.get('promiscuousMode', 0)
@@ -74,7 +77,9 @@ class Radio(object):
         self._init_interrupt()
 
     def _init_gpio(self):
-        GPIO.setmode(GPIO.BOARD)
+        if self.board_pin_numbers:
+            GPIO.setmode(GPIO.BOARD)
+
         GPIO.setup(self.intPin, GPIO.IN)
         GPIO.setup(self.rstPin, GPIO.OUT)
 


### PR DESCRIPTION
Currently this library forces its users to use `BOARD` pin numbers (an alternative to `BCM` pin numbers). This PR keeps this behaviour by default, but allows user to disable it.

Related:
* https://github.com/etrombly/RFM69/pull/33 (https://github.com/krzykro2/RFM69/commit/cf0b42335bbfb79bc093d6a4bdac2297326b45b0)
* https://github.com/ingoha/RFM69/commit/91da6428427224424c65d62d3df30509bfba5d03, https://github.com/ingoha/RFM69/commit/134bf979f9a2fb8440a35faa9d9173e9b0618d45
* https://github.com/supershiye/RFM69/commit/db413bce5c7ac35480dcf917e360684387561050