### PR TITLE
Don’t reset GPIO when shutting down the radio

### DIFF
--- a/RFM69/radio.py
+++ b/RFM69/radio.py
@@ -442,7 +442,6 @@ class Radio(object):
         """
         self._setHighPower(False)
         self.sleep()
-        GPIO.cleanup()
 
     def __str__(self):
         return "Radio RFM69"

--- a/build/lib/RFM69/radio.py
+++ b/build/lib/RFM69/radio.py
@@ -442,7 +442,6 @@ class Radio(object):
         """
         self._setHighPower(False)
         self.sleep()
-        GPIO.cleanup()
 
     def __str__(self):
         return "Radio RFM69"

--- a/build/lib/RFM69/radio_archive.py
+++ b/build/lib/RFM69/radio_archive.py
@@ -289,7 +289,6 @@ class Radio(object):
         """
         self._setHighPower(False)
         self.sleep()
-        GPIO.cleanup()
 
     def getPackets(self):
         """Get newly received packets.


### PR DESCRIPTION
Other parts of the program may still need it working.