### PR TITLE
Update hookup.rst

### DIFF
--- a/docs/source/hookup.rst
+++ b/docs/source/hookup.rst
@@ -18,7 +18,7 @@ Pinout guide
 
     PI Name, 3v3 [#f1]_ ,	Ground,	MOSI, MISO, SCLK, ID_SC [#f2]_ , CE0	 
     PI GPIO [#f3]_, , , 10, 9, 11, , 8, 5
-    PI Pin, 17, 25, 19, 21, 23, 18, 24, 29
+    PI Pin, 17, 25, 19, 21, 23, 28, 24, 29
     Adafruit, Vin, GND, MOSI, MISO, CLK, G0, CS, RST
     Sparkfun, 3.3v, GND, MOSI,	MISO, SCK, DIO0, NSS, RESET
 


### PR DESCRIPTION
Suggesting a doc fix in PI Pin.
The PI Pin for ID_SC shows 18... I think the correct one should be 28... typo?
Also, in the code, under radio.py (self.intPin = kwargs.get('interruptPin', 18))  is that right?