### PR TITLE
Extend registers retrieved to include High Power PA settings

### DIFF
--- a/RFM69/radio.py
+++ b/RFM69/radio.py
@@ -290,7 +290,7 @@ class Radio:
             list: Register values
         """
         results = []
-        for address in range(1, 0x50):
+        for address in range(1, 0x5D):
             results.append([str(hex(address)), str(bin(self._readReg(address)))])
         return results
 


### PR DESCRIPTION
As per the spec (`3.3.7. High Power Settings`), there are some registers of interest for the power amplifier blocks one and two :
```
Register, Address, Value for High Power, Value for Rx or PA0 use, Description
RegTestPa1, 0x5A, 0x5D, 0x55, High power PA control
RegTestPa2, 0x5C, 0x7C, 0x70, High power PA control
```