### PR TITLE
Reduce hang while sending

### DIFF
--- a/RFM69/radio.py
+++ b/RFM69/radio.py
@@ -469,7 +469,8 @@ class Radio:
 
         with self._sendLock:
             self._setMode(RF69_MODE_TX)
-            self._sendLock.wait(1.0)
+            while (self._readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PACKETSENT) == 0x00:
+                pass
         self._setMode(RF69_MODE_RX)
 
     def _readRSSI(self, forceTrigger=False):


### PR DESCRIPTION
#22 #13 
I don't really know anything at all about threading and locks, but reverting this part to the original code from etrombly/RFM69 seems to work and allows the radio to return to return to listen mode after a few milliseconds instead of one second.